### PR TITLE
add shebang and make pneumocat2.py executable

### DIFF
--- a/pneumocat2.py
+++ b/pneumocat2.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 """python 3.6+, tested with Mash version 2.1 and 2.2
 Main PneumoCaT2 script run serotyping from WGS data (Fastq or assembly)
 1. Run MASH screen tsv output -> tmp folder


### PR DESCRIPTION
This small change means that pneumocat2.py can be run with needing the python command